### PR TITLE
Move to version based updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
 # Changelog
 
-## 2016-04-29 - run npm prune ([7bbc8d8](https://github.com/oddhill/oddenvironment/commit/7bbc8d8656aa56d8f846759abfd0e30a76802e00))
-Make sure to remove packages that is not in package.json
+## v1.0.0
+Initial release

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,7 @@
+# Contribute
+
+## Releases
+
+- commit your changes on `master`
+- `npm version <major|minor|patch>`
+- `git push && git push --tags` (or `git push` with `git config --global push.followTags true` on latest git)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oddenv",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "dependencies": {
     "bower": "^1.7.7",
     "generator-odd": "^1.0.2",

--- a/scripts/oddenv.sh
+++ b/scripts/oddenv.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+if [[ $EUID -eq 0 ]]; then
+   echo "Hold your horses! I refuse to run this as root."
+   exit 1
+fi
+
+if [[ "$1" = "services" ]]; then
+  node $ODDENV_DIR/scripts/services.js $2 $3
+  exit 0
+fi
+
+test -f "/etc/facter/facts.d/oddenv.txt" || echo oddenv_dir=$ODDENV_DIR | sudo tee -a /etc/facter/facts.d/oddenv.txt
+
+cd $ODDENV_DIR
+./scripts/satisfy.sh
+
+# Update function
 function update {
   # If not up-to-date, update!
   git checkout $1
@@ -15,21 +31,6 @@ function update {
   sudo brew services restart dnsmasq
   brew services restart mysql56
 }
-
-if [[ $EUID -eq 0 ]]; then
-   echo "Hold your horses! I refuse to run this as root."
-   exit 1
-fi
-
-if [[ "$1" = "services" ]]; then
-  node $ODDENV_DIR/scripts/services.js $2 $3
-  exit 0
-fi
-
-test -f "/etc/facter/facts.d/oddenv.txt" || echo oddenv_dir=$ODDENV_DIR | sudo tee -a /etc/facter/facts.d/oddenv.txt
-
-cd $ODDENV_DIR
-./scripts/satisfy.sh
 
 # Get tags from master
 git fetch origin master --tags

--- a/scripts/oddenv.sh
+++ b/scripts/oddenv.sh
@@ -55,5 +55,5 @@ if [ $currentTag = $latestTag ] && command -v node >/dev/null 2>&1 && [ "$1" != 
   exit 0
 fi
 
-# This will run if `--force` is true.
+# This will run if the above fails
 update $latestTag

--- a/scripts/oddenv.sh
+++ b/scripts/oddenv.sh
@@ -43,7 +43,6 @@ currentBranch=$(git rev-parse --abbrev-ref HEAD)
 # If on master, checkout latest tag (version)
 # Probably the first time you run `oddenv`
 if [ $currentBranch = "master" ]; then
-  git checkout $latestTag
   update $latestTag
   exit 0
 fi


### PR DESCRIPTION
As discussed in #13 we should move to version based updates instead of pulling latest commits from master. We should also keep a changelog so it's easy to follow whats happened since last release.
